### PR TITLE
Added rules for smaller views to make it better

### DIFF
--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -94,6 +94,10 @@ body {
     min-height: 70vh;
     width: 80%;
 
+    @media only screen and (max-width: 900px) {
+        width: 100%;
+    }
+
     p {
         margin: 0 0 3em 0;
         font-size: 125%;
@@ -112,6 +116,12 @@ body {
         background: $COLOR-BUTTON-BG;
         color: $COLOR-TEXT;
         text-decoration: none;
+
+        @media only screen and (max-width: 900px) {
+            width: 100%;
+            display: grid;
+            place-items: center;
+        }
     }
 }
 


### PR DESCRIPTION
* The main content takes up 100% width if on a smaller screen
* The request access button will now take up the entire width if on a smaller screen

<img width="419" alt="Screenshot 2020-08-09 at 21 23 57" src="https://user-images.githubusercontent.com/2313704/89741137-a3fd9800-da86-11ea-9466-9c9763bd7c5c.png">
